### PR TITLE
Use six as fallback for setuptools > 18

### DIFF
--- a/escposprinter/escpos.py
+++ b/escposprinter/escpos.py
@@ -7,7 +7,10 @@
 '''
 import codecs
 
-from setuptools.compat import unicode
+try:
+    from setuptools.compat import unicode
+except ImportError:
+    from six import text_type as unicode
 
 from escposprinter.constants import *
 from escposprinter.exceptions import *


### PR DESCRIPTION
setuptools 19 and above use six for compatibilty instead of compat.py
