### PR TITLE
printer.py

### DIFF
--- a/escposprinter/printer.py
+++ b/escposprinter/printer.py
@@ -42,12 +42,17 @@ class Usb(Escpos):
         self.device = usb.core.find(idVendor=self.idVendor, idProduct=self.idProduct)
         if self.device is None:
             print ("Cable isn't plugged in")
-
-        if self.device.is_kernel_driver_active(0):
-            try:
-                self.device.detach_kernel_driver(0)
-            except usb.core.USBError as e:
-                print ("Could not detatch kernel driver: %s" % str(e))
+        
+        try:
+            if self.device.is_kernel_driver_active(0):
+                try:
+                    self.device.detach_kernel_driver(0)
+                except usb.core.USBError as e:
+                    print ("Could not detatch kernel driver: %s" % str(e))
+                except Exception as e:
+                    print (str(e))
+        except Exception as e:
+                print (str(e))
 
         try:
             self.device.set_configuration()


### PR DESCRIPTION
Using escposprinter in windows , it is depends on libusb0.dll . It doesn't have is_kernel_active_function() in it so it throws not implemented error. Adding another catch for this error, makes escposprinter working fine in windows.

```
'if self.device.is_kernel_driver_active(0):
        try:
            self.device.detach_kernel_driver(0)
        except usb.core.USBError as e:
            print ("Could not detatch kernel driver: %s" % str(e))'
```

 i replace above line in escposprinter/printer.py with the below line
 ```
   'try:
        if self.device.is_kernel_driver_active(0):
            try:
                self.device.detach_kernel_driver(0)
            except usb.core.USBError as e:
                print ("Could not detatch kernel driver: %s" % str(e))
            except Exception as e:
                print (str(e))
    except Exception as e:
        print (str(e))'
```